### PR TITLE
Error in localization section in almost all templates

### DIFF
--- a/Mask-Template/main.xml
+++ b/Mask-Template/main.xml
@@ -8,7 +8,7 @@
         Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
     -->
     <Localization directory="loc" default="english.txt">
-        <loc file="english.txt" language="english.txt"/>
+        <loc file="english.txt" language="english"/>
     </Localization>
     <!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
 

--- a/Material-Template/main.xml
+++ b/Material-Template/main.xml
@@ -8,7 +8,7 @@
         Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
     -->
     <Localization directory="loc" default="english.txt">
-        <loc file="english.txt" language="english.txt"/>
+        <loc file="english.txt" language="english"/>
     </Localization>
     <!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
 

--- a/Melee-Template/main.xml
+++ b/Melee-Template/main.xml
@@ -8,7 +8,7 @@
         Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
     -->
     <Localization directory="loc" default="english.txt">
-        <loc file="english.txt" language="english.txt"/>
+        <loc file="english.txt" language="english"/>
     </Localization>
     <!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
 

--- a/Pattern-Template/main.xml
+++ b/Pattern-Template/main.xml
@@ -8,7 +8,7 @@
         Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
     -->
     <Localization directory="loc" default="english.txt">
-        <loc file="english.txt" language="english.txt"/>
+        <loc file="english.txt" language="english"/>
     </Localization>
     <!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
       

--- a/Sight-Template/main.xml
+++ b/Sight-Template/main.xml
@@ -8,7 +8,7 @@
 		Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
 	-->
 	<Localization directory="loc" default="english.txt">
-		<loc file="english.txt" language="english.txt"/>
+		<loc file="english.txt" language="english"/>
 	</Localization>
 	<!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
 	<WeaponMod id="wpn_upg_o_YOUR_SIGHT_NAME" based_on="wpn_fps_upg_o_eotech" type="sight" inherit_weapons="true" inherit_adds="true" inherit_override="true" inherit_parts_override="true" inherit_parts_forbids="true" ver="2">

--- a/Weapon-Template/main.xml
+++ b/Weapon-Template/main.xml
@@ -8,7 +8,7 @@
 		Read more about the module > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/ModAssetModule
 	-->
 	<Localization directory="loc" default="english.txt">
-		<loc file="english.txt" language="english.txt"/>
+		<loc file="english.txt" language="english"/>
 	</Localization>
 	<!-- For adding more languages, read > https://github.com/simon-wh/PAYDAY-2-BeardLib/wiki/LocalizationModule -->
 	<WeaponMod id="wpn_fps_YOUR_WEAPON_NAME_barrel" based_on="wpn_fps_m4_uupg_b_medium_vanilla" type="barrel" wpn_pts="wpn_fps_YOUR_WEAPON_NAME" hidden="true" ver="2"/>


### PR DESCRIPTION
I believe it functions correctly in English due to the fact that it is set to be default, however, with this .txt extension it doesn't work in other languages